### PR TITLE
Fix issue where regex was too sensitive

### DIFF
--- a/src/main/java/com/codyi/xml2axml/chunks/ValueChunk.java
+++ b/src/main/java/com/codyi/xml2axml/chunks/ValueChunk.java
@@ -40,7 +40,7 @@ public class ValueChunk extends Chunk<Chunk.EmptyHeader> {
     byte type = -1;
     int data = -1;
 
-    Pattern explicitType = Pattern.compile("!(?:(\\w+)!)?(.*)");
+    Pattern explicitType = Pattern.compile("^!(?:(string|str|null|)!)?(.*)");
     Pattern types = Pattern.compile(("^(?:" +
             "(@null)" +
             "|(@\\+?(?:\\w+:)?\\w+/\\w+|@(?:\\w+:)?[0-9a-zA-Z]+)" +


### PR DESCRIPTION
Regex was a bit too sensitive for specific cases I was trying parse, where it would catch any string (usually regexs used for deeplinking) that contained any `!` character. This explicitly checks for the `string`, `str`, `null` or empty values that use the `!` for explicit types. 

Confirmed to fix the issue with specific strings containing `!`.